### PR TITLE
Move to Netty5 package names

### DIFF
--- a/codec-extras/pom.xml
+++ b/codec-extras/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>netty-codec-extras</artifactId>
-    <version>${parent.version}</version>
+    <version>${project.parent.version}</version>
     <name>Netty/Codec/Extras</name>
     <packaging>jar</packaging>
 
@@ -23,22 +23,22 @@
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
+            <artifactId>netty5-common</artifactId>
             <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
+            <artifactId>netty5-buffer</artifactId>
             <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
+            <artifactId>netty5-transport</artifactId>
             <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
+            <artifactId>netty5-codec</artifactId>
             <version>${netty.version}</version>
         </dependency>
 
@@ -90,7 +90,7 @@
         <!-- For SocketObjectEchoTest -->
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-testsuite</artifactId>
+            <artifactId>netty5-testsuite</artifactId>
             <version>${netty.version}</version>
             <scope>test</scope>
         </dependency>

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
@@ -15,16 +15,16 @@
  */
 package io.netty.contrib.handler.codec.json;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.CorruptedFrameException;
-import io.netty.handler.codec.TooLongFrameException;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufUtil;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.CorruptedFrameException;
+import io.netty5.handler.codec.TooLongFrameException;
 
-import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty5.util.internal.ObjectUtil.checkPositive;
 
 /**
  * Splits a byte stream of JSON objects and arrays into individual objects/arrays and passes them up the

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteInput.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteInput.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.ByteBuf;
 import org.jboss.marshalling.ByteInput;
 
 import java.io.IOException;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteOutput.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteOutput.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.ByteBuf;
 import org.jboss.marshalling.ByteOutput;
 
 import java.io.IOException;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ContextBoundUnmarshallerProvider.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ContextBoundUnmarshallerProvider.java
@@ -15,11 +15,11 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.util.Attribute;
+import io.netty5.util.AttributeKey;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.Unmarshaller;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/DefaultMarshallerProvider.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/DefaultMarshallerProvider.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelHandlerContext;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/DefaultUnmarshallerProvider.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/DefaultUnmarshallerProvider.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelHandlerContext;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.Unmarshaller;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallerProvider.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallerProvider.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelHandlerContext;
 import org.jboss.marshalling.Marshaller;
 
 /**

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingDecoder.java
@@ -15,10 +15,10 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.TooLongFrameException;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty5.handler.codec.TooLongFrameException;
 import org.jboss.marshalling.ByteInput;
 import org.jboss.marshalling.Unmarshaller;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingEncoder.java
@@ -15,10 +15,10 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandler.Sharable;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.MessageToByteEncoder;
 import org.jboss.marshalling.Marshaller;
 
 /**

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ThreadLocalMarshallerProvider.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ThreadLocalMarshallerProvider.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.FastThreadLocal;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.util.concurrent.FastThreadLocal;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ThreadLocalUnmarshallerProvider.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ThreadLocalUnmarshallerProvider.java
@@ -15,14 +15,14 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.FastThreadLocal;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.util.concurrent.FastThreadLocal;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.Unmarshaller;
 
 /**
- * {@link io.netty.handler.codec.marshalling.UnmarshallerProvider} implementation which use a {@link ThreadLocal} to store references
+ * {@link io.netty.contrib.handler.codec.marshalling.UnmarshallerProvider} implementation which use a {@link ThreadLocal} to store references
  * to {@link Unmarshaller} instances. This may give you some performance boost if you need to unmarshall
  * many small {@link Object}'s.
  */

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/UnmarshallerProvider.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/UnmarshallerProvider.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelHandlerContext;
 import org.jboss.marshalling.Unmarshaller;
 
 /**

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoder.java
@@ -19,15 +19,15 @@ import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.LengthFieldPrepender;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufUtil;
+import io.netty5.channel.ChannelHandler.Sharable;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty5.handler.codec.LengthFieldPrepender;
+import io.netty5.handler.codec.MessageToMessageDecoder;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoderNano.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoderNano.java
@@ -16,14 +16,14 @@
 package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.nano.MessageNano;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufUtil;
+import io.netty5.channel.ChannelHandler.Sharable;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty5.handler.codec.MessageToMessageDecoder;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoder.java
@@ -18,17 +18,17 @@ package io.netty.contrib.handler.codec.protobuf;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.MessageLiteOrBuilder;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.LengthFieldPrepender;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandler.Sharable;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty5.handler.codec.LengthFieldPrepender;
+import io.netty5.handler.codec.MessageToMessageEncoder;
 
 import java.util.List;
 
-import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty5.buffer.Unpooled.wrappedBuffer;
 
 /**
  * Encodes the requested <a href="https://github.com/google/protobuf">Google

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoderNano.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoderNano.java
@@ -17,13 +17,13 @@ package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.nano.CodedOutputByteBufferNano;
 import com.google.protobuf.nano.MessageNano;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.LengthFieldPrepender;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty5.handler.codec.LengthFieldPrepender;
+import io.netty5.handler.codec.MessageToMessageEncoder;
 
 import java.util.List;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -17,10 +17,10 @@ package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.nano.CodedInputByteBufferNano;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.CorruptedFrameException;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.CorruptedFrameException;
 
 /**
  * A decoder that splits the received {@link ByteBuf}s dynamically by the

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
@@ -17,10 +17,10 @@ package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.nano.CodedOutputByteBufferNano;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandler.Sharable;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.MessageToByteEncoder;
 
 /**
  * An encoder that prepends the Google Protocol Buffers

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/package-info.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/package-info.java
@@ -18,6 +18,6 @@
  * Encoder and decoder which transform a
  * <a href="https://github.com/google/protobuf">Google Protocol Buffers</a>
  * {@link com.google.protobuf.Message} and {@link com.google.protobuf.nano.MessageNano} into a
- * {@link io.netty.buffer.ByteBuf} and vice versa.
+ * {@link io.netty5.buffer.ByteBuf} and vice versa.
  */
 package io.netty.contrib.handler.codec.protobuf;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ClassResolvers.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ClassResolvers.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.util.internal.PlatformDependent;
+import io.netty5.util.internal.PlatformDependent;
 
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoder.java
@@ -15,17 +15,17 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufOutputStream;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufOutputStream;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.MessageToByteEncoder;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 
-import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * An encoder which serializes a Java object into a {@link ByteBuf}

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectDecoder.java
@@ -15,10 +15,10 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufInputStream;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufInputStream;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoder.java
@@ -15,11 +15,11 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufOutputStream;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufOutputStream;
+import io.netty5.channel.ChannelHandler.Sharable;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.MessageToByteEncoder;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoderOutputStream.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoderOutputStream.java
@@ -15,9 +15,9 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufOutputStream;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufOutputStream;
+import io.netty5.buffer.Unpooled;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoder.java
@@ -15,13 +15,13 @@
  */
 package io.netty.contrib.handler.codec.xml;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.CorruptedFrameException;
-import io.netty.handler.codec.TooLongFrameException;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.CorruptedFrameException;
+import io.netty5.handler.codec.TooLongFrameException;
 
-import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty5.util.internal.ObjectUtil.checkPositive;
 
 /**
  * A frame decoder for single separate XML based message streams.

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/json/JsonObjectDecoderTest.java
@@ -15,12 +15,12 @@
  */
 package io.netty.contrib.handler.codec.json;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.CorruptedFrameException;
-import io.netty.handler.codec.TooLongFrameException;
-import io.netty.util.CharsetUtil;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.Unpooled;
+import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.codec.CorruptedFrameException;
+import io.netty5.handler.codec.TooLongFrameException;
+import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingDecoderTest.java
@@ -15,10 +15,10 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.Unpooled;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.embedded.EmbeddedChannel;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingEncoderTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.embedded.EmbeddedChannel;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingDecoderTest.java
@@ -15,11 +15,11 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.CodecException;
-import io.netty.handler.codec.TooLongFrameException;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.Unpooled;
+import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.codec.CodecException;
+import io.netty5.handler.codec.TooLongFrameException;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingEncoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.ByteBuf;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingDecoderTest.java
@@ -15,11 +15,11 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.CodecException;
-import io.netty.handler.codec.TooLongFrameException;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.Unpooled;
+import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.codec.CodecException;
+import io.netty5.handler.codec.TooLongFrameException;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingEncoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.ByteBuf;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
@@ -15,12 +15,12 @@
  */
 package io.netty.contrib.handler.codec.protobuf;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty5.buffer.Unpooled.wrappedBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -15,12 +15,12 @@
  */
 package io.netty.contrib.handler.codec.protobuf;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty5.buffer.Unpooled.wrappedBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoderTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufInputStream;
-import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufInputStream;
+import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/SocketObjectEchoTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/SocketObjectEchoTest.java
@@ -15,14 +15,14 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
-import io.netty.testsuite.transport.socket.AbstractSocketTest;
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelOption;
+import io.netty5.testsuite.transport.socket.AbstractSocketTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoderTest.java
@@ -16,13 +16,13 @@
 
 package io.netty.contrib.handler.codec.xml;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.CorruptedFrameException;
-import io.netty.handler.codec.TooLongFrameException;
-import io.netty.util.CharsetUtil;
-import io.netty.util.internal.EmptyArrays;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.Unpooled;
+import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.codec.CorruptedFrameException;
+import io.netty5.handler.codec.TooLongFrameException;
+import io.netty5.util.CharsetUtil;
+import io.netty5.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>netty-codec-extras-examples</artifactId>
-    <version>${parent.version}</version>
+    <version>${project.parent.version}</version>
 
     <dependencies>
         <dependency>
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
+            <artifactId>netty5-handler</artifactId>
             <version>${netty.version}</version>
         </dependency>
     </dependencies>

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClient.java
@@ -15,20 +15,20 @@
  */
 package io.netty.contrib.handler.codec.example.objectecho;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.nio.NioHandler;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.nio.NioHandler;
+import io.netty5.channel.socket.SocketChannel;
+import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty.contrib.handler.codec.serialization.ClassResolvers;
 import io.netty.contrib.handler.codec.serialization.ObjectDecoder;
 import io.netty.contrib.handler.codec.serialization.ObjectEncoder;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 
 /**
  * Modification of {@code EchoClient} which utilizes Java object serialization.

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClientHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClientHandler.java
@@ -15,14 +15,14 @@
  */
 package io.netty.contrib.handler.codec.example.objectecho;
 
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.util.concurrent.Future;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.netty.channel.ChannelFutureListeners.FIRE_EXCEPTION_ON_FAILURE;
+import static io.netty5.channel.ChannelFutureListeners.FIRE_EXCEPTION_ON_FAILURE;
 
 /**
  * Handler implementation for the object echo client.  It initiates the

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServer.java
@@ -15,22 +15,22 @@
  */
 package io.netty.contrib.handler.codec.example.objectecho;
 
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.nio.NioHandler;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.nio.NioHandler;
+import io.netty5.channel.socket.SocketChannel;
+import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty.contrib.handler.codec.serialization.ClassResolvers;
 import io.netty.contrib.handler.codec.serialization.ObjectDecoder;
 import io.netty.contrib.handler.codec.serialization.ObjectEncoder;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty5.handler.logging.LogLevel;
+import io.netty5.handler.logging.LoggingHandler;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.util.SelfSignedCertificate;
 
 /**
  * Modification of {@code EchoServer} which utilizes Java object serialization.

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServerHandler.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.example.objectecho;
 
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.ChannelHandlerContext;
 
 /**
  * Handles both client-side and server-side handler depending on which

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClient.java
@@ -15,15 +15,15 @@
  */
 package io.netty.contrib.handler.codec.example.worldclock;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.nio.NioHandler;
-import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.channel.Channel;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.nio.NioHandler;
+import io.netty5.channel.socket.nio.NioSocketChannel;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 
 import java.util.Arrays;
 import java.util.List;

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClientHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClientHandler.java
@@ -15,9 +15,9 @@
  */
 package io.netty.contrib.handler.codec.example.worldclock;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty.contrib.handler.codec.example.worldclock.WorldClockProtocol.Continent;
 import io.netty.contrib.handler.codec.example.worldclock.WorldClockProtocol.LocalTime;
 import io.netty.contrib.handler.codec.example.worldclock.WorldClockProtocol.LocalTimes;

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClientInitializer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClientInitializer.java
@@ -15,14 +15,14 @@
  */
 package io.netty.contrib.handler.codec.example.worldclock;
 
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.SocketChannel;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.socket.SocketChannel;
 import io.netty.contrib.handler.codec.protobuf.ProtobufDecoder;
 import io.netty.contrib.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.contrib.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
 import io.netty.contrib.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
-import io.netty.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContext;
 
 public class WorldClockClientInitializer extends ChannelInitializer<SocketChannel> {
 

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServer.java
@@ -15,16 +15,16 @@
  */
 package io.netty.contrib.handler.codec.example.worldclock;
 
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.nio.NioHandler;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.nio.NioHandler;
+import io.netty5.channel.socket.nio.NioServerSocketChannel;
+import io.netty5.handler.logging.LogLevel;
+import io.netty5.handler.logging.LoggingHandler;
+import io.netty5.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContextBuilder;
+import io.netty5.handler.ssl.util.SelfSignedCertificate;
 
 /**
  * Receives a list of continent/city pairs from a {@link WorldClockClient} to

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServerHandler.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.example.worldclock;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty.contrib.handler.codec.example.worldclock.WorldClockProtocol.Continent;
 import io.netty.contrib.handler.codec.example.worldclock.WorldClockProtocol.DayOfWeek;
 import io.netty.contrib.handler.codec.example.worldclock.WorldClockProtocol.LocalTime;

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServerInitializer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServerInitializer.java
@@ -15,14 +15,14 @@
  */
 package io.netty.contrib.handler.codec.example.worldclock;
 
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.SocketChannel;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelPipeline;
+import io.netty5.channel.socket.SocketChannel;
 import io.netty.contrib.handler.codec.protobuf.ProtobufDecoder;
 import io.netty.contrib.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.contrib.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
 import io.netty.contrib.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
-import io.netty.handler.ssl.SslContext;
+import io.netty5.handler.ssl.SslContext;
 
 public class WorldClockServerInitializer extends ChannelInitializer<SocketChannel> {
 

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <profile>
             <id>leak</id>
             <properties>
-                <test.argLine>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=32
+                <test.argLine>-Dio.netty5.leakDetectionLevel=paranoid -Dio.netty5.leakDetection.targetRecords=32
                 </test.argLine>
             </properties>
         </profile>


### PR DESCRIPTION
Motivation:
Use the latest Netty 5 binaries.

Modifications:
Move to Netty 5 package names

Result:
Use the latest Netty 5 binaries.