### PR TITLE
Adapt examples to new netty5 API

### DIFF
--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClient.java
@@ -60,7 +60,7 @@ public final class ObjectEchoClient {
                         public void initChannel(SocketChannel ch) throws Exception {
                             ChannelPipeline p = ch.pipeline();
                             if (sslCtx != null) {
-                                p.addLast(sslCtx.newHandler(ch.alloc(), HOST, PORT));
+                                p.addLast(sslCtx.newHandler(ch.bufferAllocator(), HOST, PORT));
                             }
                             p.addLast(
                                     new ObjectEncoder(),

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServer.java
@@ -62,7 +62,7 @@ public final class ObjectEchoServer {
                         public void initChannel(SocketChannel ch) throws Exception {
                             ChannelPipeline p = ch.pipeline();
                             if (sslCtx != null) {
-                                p.addLast(sslCtx.newHandler(ch.alloc()));
+                                p.addLast(sslCtx.newHandler(ch.bufferAllocator()));
                             }
                             p.addLast(
                                     new ObjectEncoder(),

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClientInitializer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClientInitializer.java
@@ -36,7 +36,7 @@ public class WorldClockClientInitializer extends ChannelInitializer<SocketChanne
     public void initChannel(SocketChannel ch) {
         ChannelPipeline p = ch.pipeline();
         if (sslCtx != null) {
-            p.addLast(sslCtx.newHandler(ch.alloc(), WorldClockClient.HOST, WorldClockClient.PORT));
+            p.addLast(sslCtx.newHandler(ch.bufferAllocator(), WorldClockClient.HOST, WorldClockClient.PORT));
         }
 
         p.addLast(new ProtobufVarint32FrameDecoder());

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServerInitializer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServerInitializer.java
@@ -36,7 +36,7 @@ public class WorldClockServerInitializer extends ChannelInitializer<SocketChanne
     public void initChannel(SocketChannel ch) throws Exception {
         ChannelPipeline p = ch.pipeline();
         if (sslCtx != null) {
-            p.addLast(sslCtx.newHandler(ch.alloc()));
+            p.addLast(sslCtx.newHandler(ch.bufferAllocator()));
         }
 
         p.addLast(new ProtobufVarint32FrameDecoder());


### PR DESCRIPTION
Please consider to merge this PR, which adapts the codec-extras examples to the new Netty5 API
(the SslContext.newHandler method is now requiring a parameter with a io.netty5.buffer.api.BufferAllocator type).