### PR TITLE
Adapt JsonObjectDecoder to new netty5 buffer API

### DIFF
--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2021-2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,12 +15,12 @@
  */
 package io.netty.contrib.handler.codec.json;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
+import io.netty5.buffer.ByteBufUtil;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.codec.CorruptedFrameException;
 import io.netty5.handler.codec.TooLongFrameException;
 
@@ -39,7 +39,7 @@ import static io.netty5.util.internal.ObjectUtil.checkPositive;
  * if it contains a matching number of opening and closing braces/brackets. It's up to a subsequent
  * {@link ChannelHandler} to parse the JSON text into a more usable form i.e. a POJO.
  */
-public class JsonObjectDecoder extends ByteToMessageDecoder {
+public class JsonObjectDecoder extends ByteToMessageDecoderForBuffer {
 
     private static final int ST_CORRUPTED = -1;
     private static final int ST_INIT = 0;
@@ -48,8 +48,8 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
     private final int maxObjectLength;
     private final boolean streamArrayElements;
     private int openBraces;
-    private int idx;
-    private int lastReaderIndex;
+    private int idx; // current scan position
+    private int lastReaderOffset;
     private int state;
     private boolean insideString;
 
@@ -80,29 +80,29 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         if (state == ST_CORRUPTED) {
-            in.skipBytes(in.readableBytes());
+            in.skipReadable(in.readableBytes());
             return;
         }
 
-        if (idx > in.readerIndex() && lastReaderIndex != in.readerIndex()) {
-            idx = in.readerIndex() + idx - lastReaderIndex;
+        if (idx > in.readerOffset() && lastReaderOffset != in.readerOffset()) {
+            idx = in.readerOffset() + idx - lastReaderOffset;
         }
 
         // index of next byte to process.
         int idx = this.idx;
-        int wrtIdx = in.writerIndex();
+        int wrtOffset = in.writerOffset();
 
-        if (wrtIdx > maxObjectLength) {
+        if (wrtOffset > maxObjectLength) {
             // buffer size exceeded maxObjectLength; discarding the complete buffer.
-            in.skipBytes(in.readableBytes());
+            in.skipReadable(in.readableBytes());
             reset();
             throw new TooLongFrameException(
-                    "object length exceeds " + maxObjectLength + ": " + wrtIdx + " bytes discarded");
+                    "object length exceeds " + maxObjectLength + ": " + wrtOffset + " bytes discarded");
         }
 
-        for (/* use current idx */; idx < wrtIdx; idx++) {
+        for (/* use current idx */; idx < wrtOffset; idx++) {
             byte c = in.getByte(idx);
             if (state == ST_DECODING_NORMAL) {
                 decodeByte(c, in, idx);
@@ -110,14 +110,24 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
                 // All opening braces/brackets have been closed. That's enough to conclude
                 // that the JSON object/array is complete.
                 if (openBraces == 0) {
-                    ByteBuf json = extractObject(ctx, in, in.readerIndex(), idx + 1 - in.readerIndex());
+                    Buffer json = extractObject(ctx, in, in.readerOffset(), idx + 1 - in.readerOffset());
                     if (json != null) {
                         ctx.fireChannelRead(json);
                     }
 
-                    // The JSON object/array was extracted => discard the bytes from
-                    // the input buffer.
-                    in.readerIndex(idx + 1);
+                    int newWrtOffset = in.writerOffset();
+                    if (wrtOffset > newWrtOffset) {
+                        // The JSON object/array was extracted using split or readSplit ==>
+                        // reset current scan index so next iteration will correspond to first position.
+                        // Also reset input buffer writer offset.
+                        idx = -1;
+                        wrtOffset = newWrtOffset;
+                    } else {
+                        // The JSON object/array was extracted not using split/readSplit ==>
+                        // discard the bytes from the input buffer.
+                        in.readerOffset(idx + 1);
+                    }
+
                     // Reset the object state to get ready for the next JSON object/text
                     // coming along the byte stream.
                     reset();
@@ -128,22 +138,33 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
                 if (!insideString && (openBraces == 1 && c == ',' || openBraces == 0 && c == ']')) {
                     // skip leading spaces. No range check is needed and the loop will terminate
                     // because the byte at position idx is not a whitespace.
-                    for (int i = in.readerIndex(); Character.isWhitespace(in.getByte(i)); i++) {
-                        in.skipBytes(1);
+                    for (int i = in.readerOffset(); Character.isWhitespace(in.getByte(i)); i++) {
+                        in.skipReadable(1);
                     }
 
                     // skip trailing spaces.
                     int idxNoSpaces = idx - 1;
-                    while (idxNoSpaces >= in.readerIndex() && Character.isWhitespace(in.getByte(idxNoSpaces))) {
+                    while (idxNoSpaces >= in.readerOffset() && Character.isWhitespace(in.getByte(idxNoSpaces))) {
                         idxNoSpaces--;
                     }
 
-                    ByteBuf json = extractObject(ctx, in, in.readerIndex(), idxNoSpaces + 1 - in.readerIndex());
+                    Buffer json = extractObject(ctx, in, in.readerOffset(), idxNoSpaces + 1 - in.readerOffset());
                     if (json != null) {
                         ctx.fireChannelRead(json);
                     }
 
-                    in.readerIndex(idx + 1);
+                    int newWrtOffset = in.writerOffset();
+                    if (wrtOffset > newWrtOffset) {
+                        // The JSON object/array was extracted using split or readSplit ==>
+                        // reset current scan index accordingly, as well as the input buffer writer offset.
+                        idx = idx - idxNoSpaces - 1;
+                        in.readerOffset(idx + 1);
+                        wrtOffset = newWrtOffset;
+                    } else {
+                        // The JSON object/array was extracted not using split or readSplit ==>
+                        // discard the bytes from the input buffer.
+                        in.readerOffset(idx + 1);
+                    }
 
                     if (c == ']') {
                         reset();
@@ -155,11 +176,11 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
 
                 if (state == ST_DECODING_ARRAY_STREAM) {
                     // Discard the array bracket
-                    in.skipBytes(1);
+                    in.skipReadable(1);
                 }
                 // Discard leading spaces in front of a JSON object/array.
             } else if (Character.isWhitespace(c)) {
-                in.skipBytes(1);
+                in.skipReadable(1);
             } else {
                 state = ST_CORRUPTED;
                 throw new CorruptedFrameException(
@@ -172,18 +193,18 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
         } else {
             this.idx = idx;
         }
-        lastReaderIndex = in.readerIndex();
+        lastReaderOffset = in.readerOffset();
     }
 
     /**
      * Override this method if you want to filter the json objects/arrays that get passed through the pipeline.
      */
     @SuppressWarnings("UnusedParameters")
-    protected ByteBuf extractObject(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
-        return buffer.retainedSlice(index, length);
+    protected Buffer extractObject(ChannelHandlerContext ctx, Buffer buffer, int index, int length) {
+        return buffer.readSplit(length);
     }
 
-    private void decodeByte(byte c, ByteBuf in, int idx) {
+    private void decodeByte(byte c, Buffer in, int idx) {
         if ((c == '{' || c == '[') && !insideString) {
             openBraces++;
         } else if ((c == '}' || c == ']') && !insideString) {

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/json/JsonObjectDecoderTest.java
@@ -56,9 +56,9 @@ public class JsonObjectDecoderTest {
         }
 
         for (String part : result) {
-            Buffer res = ch.readInbound();
-            assertEquals(part, res.toString(CharsetUtil.UTF_8));
-            res.close();
+            try(Buffer res = ch.readInbound()) {
+                assertEquals(part, res.toString(CharsetUtil.UTF_8));
+            }
         }
 
         assertFalse(ch.finish());
@@ -77,9 +77,9 @@ public class JsonObjectDecoderTest {
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(),objectPart2, CharsetUtil.UTF_8));
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(),objectPart3 + "   \n\n  \n", CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals(objectPart1 + objectPart2 + objectPart3, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(objectPart1 + objectPart2 + objectPart3, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -97,9 +97,9 @@ public class JsonObjectDecoderTest {
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), objectPart3, CharsetUtil.UTF_8));
 
         for (int i = 0; i < 3; i++) {
-            Buffer res = ch.readInbound();
-            assertEquals("{\"name\":\"John\"}", res.toString(CharsetUtil.UTF_8));
-            res.close();
+            try(Buffer res = ch.readInbound()) {
+                assertEquals("{\"name\":\"John\"}", res.toString(CharsetUtil.UTF_8));
+            }
         }
 
         assertFalse(ch.finish());
@@ -122,9 +122,9 @@ public class JsonObjectDecoderTest {
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), arrayPart4, CharsetUtil.UTF_8));
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), arrayPart5 + "      ", CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals(arrayPart1 + arrayPart2 + arrayPart3 + arrayPart4 + arrayPart5, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(arrayPart1 + arrayPart2 + arrayPart3 + arrayPart4 + arrayPart5, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -186,9 +186,9 @@ public class JsonObjectDecoderTest {
             ch.writeInbound(copiedBuffer(ch.bufferAllocator(), new byte[]{c}));
         }
 
-        Buffer res = ch.readInbound();
-        assertEquals(json, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(json, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -201,9 +201,9 @@ public class JsonObjectDecoderTest {
         System.out.println(json);
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), json, CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals(json, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(json, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -216,9 +216,9 @@ public class JsonObjectDecoderTest {
         System.out.println(json);
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), json, CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals(json, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(json, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -231,9 +231,9 @@ public class JsonObjectDecoderTest {
         System.out.println(json);
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), json, CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals(json, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(json, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -248,15 +248,15 @@ public class JsonObjectDecoderTest {
 
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), object1 + object2 + object3, CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals(object1, res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals(object2, res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals(object3, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(object1, res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(object2, res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(object3, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -277,9 +277,9 @@ public class JsonObjectDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "  [1,2,3]  ", CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals("[1,2,3]", res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("[1,2,3]", res.toString(CharsetUtil.UTF_8));
+        }
 
         try {
             assertThrows(CorruptedFrameException.class,
@@ -312,15 +312,15 @@ public class JsonObjectDecoderTest {
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), object2, CharsetUtil.UTF_8));
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), object3, CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals(object1, res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals(object2, res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals(object3, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(object1, res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(object2, res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(object3, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -332,9 +332,9 @@ public class JsonObjectDecoderTest {
         String object = "{ \"key\" : \"[]{}}\\\"}}'}\"}";
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), object, CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals(object, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(object, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -349,33 +349,33 @@ public class JsonObjectDecoderTest {
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), array, CharsetUtil.UTF_8));
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), object, CharsetUtil.UTF_8));
 
-        Buffer res = ch.readInbound();
-        assertEquals("12", res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals("\"bla\"", res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals("13.4", res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals("{\"key0\" : [1,2], \"key1\" : 12, \"key2\" : {}}", res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals("true", res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals("false", res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals("null", res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals("[\"bla\", {}, [1,2,3]]", res.toString(CharsetUtil.UTF_8));
-        res.close();
-        res = ch.readInbound();
-        assertEquals(object, res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("12", res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("\"bla\"", res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("13.4", res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("{\"key0\" : [1,2], \"key1\" : 12, \"key2\" : {}}", res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("true", res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("false", res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("null", res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("[\"bla\", {}, [1,2,3]]", res.toString(CharsetUtil.UTF_8));
+        }
+        try(Buffer res = ch.readInbound()) {
+            assertEquals(object, res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }
@@ -389,25 +389,22 @@ public class JsonObjectDecoderTest {
 
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 
-        Buffer res;
-
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), part1, CharsetUtil.UTF_8));
-        res = ch.readInbound();
-        assertEquals("{\"a\":{\"b\":{\"c\":{ \"d\":\"27301\", \"med\":\"d\", \"path\":\"27310\"} }, " +
-                "\"status\":\"OK\" } }", res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("{\"a\":{\"b\":{\"c\":{ \"d\":\"27301\", \"med\":\"d\", \"path\":\"27310\"} }, " +
+                    "\"status\":\"OK\" } }", res.toString(CharsetUtil.UTF_8));
+        }
 
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), part2, CharsetUtil.UTF_8));
-        res = ch.readInbound();
-
-        assertNull(res);
+        try(Buffer res = ch.readInbound()) {
+            assertNull(res);
+        }
 
         ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "}}]}]}]}}}}", CharsetUtil.UTF_8));
-        res = ch.readInbound();
-
-        assertEquals("{\"a\":{\"b\":{\"c\":{\"ory\":[{\"competi\":[{\"event\":[{" + "\"externalI\":{" +
-                "\"external\":[{\"id\":\"O\"} ]}}]}]}]}}}}", res.toString(CharsetUtil.UTF_8));
-        res.close();
+        try(Buffer res = ch.readInbound()) {
+            assertEquals("{\"a\":{\"b\":{\"c\":{\"ory\":[{\"competi\":[{\"event\":[{" + "\"externalI\":{" +
+                    "\"external\":[{\"id\":\"O\"} ]}}]}]}]}}}}", res.toString(CharsetUtil.UTF_8));
+        }
 
         assertFalse(ch.finish());
     }

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/json/JsonObjectDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
This PR provides the support of new netty5 Buffer API for the JsonObjectDecoder.

The decoder is now extending the ByteToMessageDecoderForBuffer class, and the extractObject method is doing a readSplit instead of retainedSlice method. I tried to preserve the current logic of the parser.
I also have started to do a JMH test, in order to compare performance between old decoder based on old ByteBuffer vs this new one based on new Buffer API.

thanks.