### PR TITLE
Update to Netty 5.0.0.Alpha3-SNAPSHOT

### DIFF
--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
@@ -82,7 +82,7 @@ public class JsonObjectDecoder extends ByteToMessageDecoderForBuffer {
     @Override
     protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         if (state == ST_CORRUPTED) {
-            in.skipReadable(in.readableBytes());
+            in.skipReadableBytes(in.readableBytes());
             return;
         }
 
@@ -96,7 +96,7 @@ public class JsonObjectDecoder extends ByteToMessageDecoderForBuffer {
 
         if (wrtOffset > maxObjectLength) {
             // buffer size exceeded maxObjectLength; discarding the complete buffer.
-            in.skipReadable(in.readableBytes());
+            in.skipReadableBytes(in.readableBytes());
             reset();
             throw new TooLongFrameException(
                     "object length exceeds " + maxObjectLength + ": " + wrtOffset + " bytes discarded");
@@ -139,7 +139,7 @@ public class JsonObjectDecoder extends ByteToMessageDecoderForBuffer {
                     // skip leading spaces. No range check is needed and the loop will terminate
                     // because the byte at position idx is not a whitespace.
                     for (int i = in.readerOffset(); Character.isWhitespace(in.getByte(i)); i++) {
-                        in.skipReadable(1);
+                        in.skipReadableBytes(1);
                     }
 
                     // skip trailing spaces.
@@ -176,11 +176,11 @@ public class JsonObjectDecoder extends ByteToMessageDecoderForBuffer {
 
                 if (state == ST_DECODING_ARRAY_STREAM) {
                     // Discard the array bracket
-                    in.skipReadable(1);
+                    in.skipReadableBytes(1);
                 }
                 // Discard leading spaces in front of a JSON object/array.
             } else if (Character.isWhitespace(c)) {
-                in.skipReadable(1);
+                in.skipReadableBytes(1);
             } else {
                 state = ST_CORRUPTED;
                 throw new CorruptedFrameException(

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
     <properties>
         <nettyByteBuf.version>4.1.75.Final</nettyByteBuf.version>
-        <netty.version>5.0.0.Alpha2-SNAPSHOT</netty.version>
+        <netty.version>5.0.0.Alpha3-SNAPSHOT</netty.version>
         <netty.build.version>29</netty.build.version>
         <project.scm.id>github</project.scm.id>
         <release.gpg.keyname/>


### PR DESCRIPTION
Motivation:

Use the latest changes from Netty 5 snapshot

Modifications:

- Update to Netty 5.0.0.Alpha3-SNAPSHOT
- Adapt to the changes in the API: skipReadable() -> skipReadableBytes()

Result:

Use the latest changes from Netty 5 snapshot