### PR TITLE
Adapt the code to the changes in the ChannelHandler/ChannelHandlerContext methods names

### DIFF
--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoder.java
@@ -82,7 +82,7 @@ public class XmlFrameDecoder extends ByteToMessageDecoder {
     }
 
     private static void fail(ChannelHandlerContext ctx) {
-        ctx.fireExceptionCaught(new CorruptedFrameException("frame contains content before the xml starts"));
+        ctx.fireChannelExceptionCaught(new CorruptedFrameException("frame contains content before the xml starts"));
     }
 
     private static ByteBuf extractFrame(ByteBuf buffer, int index, int length) {

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/SocketObjectEchoTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/SocketObjectEchoTest.java
@@ -190,7 +190,7 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx,
+        public void channelExceptionCaught(ChannelHandlerContext ctx,
                 Throwable cause) throws Exception {
             if (exception.compareAndSet(null, cause)) {
                 ctx.close();

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClientHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClientHandler.java
@@ -62,7 +62,7 @@ public class ObjectEchoClientHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServerHandler.java
@@ -36,7 +36,7 @@ public class ObjectEchoServerHandler implements ChannelHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClientHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClientHandler.java
@@ -98,7 +98,7 @@ public class WorldClockClientHandler extends SimpleChannelInboundHandler<LocalTi
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServerHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServerHandler.java
@@ -72,7 +72,7 @@ public class WorldClockServerHandler extends SimpleChannelInboundHandler<Locatio
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         cause.printStackTrace();
         ctx.close();
     }


### PR DESCRIPTION
Motivation:

Some of the `ChannelHandler`/`ChannelHandlerContext` methods names are changed with
 https://github.com/netty/netty/pull/12505
The code needs adaptation.

Modifications:

- `fireExceptionCaught(...)` is now `fireChannelExceptionCaught(...)`
- `exceptionCaught(...)` is now `channelExceptionCaught(...)`

Result:

The code is adapted to the new changes in the API.