### PR TITLE
Port codec-extras to Buffer API

### DIFF
--- a/codec-extras/pom.xml
+++ b/codec-extras/pom.xml
@@ -23,11 +23,6 @@
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-            <version>${nettyByteBuf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty5-common</artifactId>
             <version>${netty.version}</version>
         </dependency>

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
@@ -20,7 +20,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.CorruptedFrameException;
 import io.netty5.handler.codec.TooLongFrameException;
 
@@ -39,7 +39,7 @@ import static io.netty5.util.internal.ObjectUtil.checkPositive;
  * if it contains a matching number of opening and closing braces/brackets. It's up to a subsequent
  * {@link ChannelHandler} to parse the JSON text into a more usable form i.e. a POJO.
  */
-public class JsonObjectDecoder extends ByteToMessageDecoderForBuffer {
+public class JsonObjectDecoder extends ByteToMessageDecoder {
 
     private static final int ST_CORRUPTED = -1;
     private static final int ST_INIT = 0;
@@ -80,7 +80,7 @@ public class JsonObjectDecoder extends ByteToMessageDecoderForBuffer {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) {
         if (state == ST_CORRUPTED) {
             in.skipReadableBytes(in.readableBytes());
             return;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteInput.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteInput.java
@@ -15,19 +15,19 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import org.jboss.marshalling.ByteInput;
 
 import java.io.IOException;
 
 /**
- * {@link ByteInput} implementation which reads its data from a {@link ByteBuf}
+ * {@link ByteInput} implementation which reads its data from a {@link Buffer}
  */
 class ChannelBufferByteInput implements ByteInput {
 
-    private final ByteBuf buffer;
+    private final Buffer buffer;
 
-    ChannelBufferByteInput(ByteBuf buffer) {
+    ChannelBufferByteInput(Buffer buffer) {
         this.buffer = buffer;
     }
 
@@ -37,25 +37,25 @@ class ChannelBufferByteInput implements ByteInput {
     }
 
     @Override
-    public int available() throws IOException {
+    public int available() {
         return buffer.readableBytes();
     }
 
     @Override
-    public int read() throws IOException {
-        if (buffer.isReadable()) {
+    public int read() {
+        if (buffer.readableBytes() > 0) {
             return buffer.readByte() & 0xff;
         }
         return -1;
     }
 
     @Override
-    public int read(byte[] array) throws IOException {
+    public int read(byte[] array) {
         return read(array, 0, array.length);
     }
 
     @Override
-    public int read(byte[] dst, int dstIndex, int length) throws IOException {
+    public int read(byte[] dst, int dstIndex, int length) {
         int available = available();
         if (available == 0) {
             return -1;
@@ -67,12 +67,12 @@ class ChannelBufferByteInput implements ByteInput {
     }
 
     @Override
-    public long skip(long bytes) throws IOException {
+    public long skip(long bytes) {
         int readable = buffer.readableBytes();
         if (readable < bytes) {
             bytes = readable;
         }
-        buffer.readerIndex((int) (buffer.readerIndex() + bytes));
+        buffer.readerOffset((int) (buffer.readerOffset() + bytes));
         return bytes;
     }
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteOutput.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteOutput.java
@@ -15,22 +15,22 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import org.jboss.marshalling.ByteOutput;
 
 import java.io.IOException;
 
 /**
- * {@link ByteOutput} implementation which writes the data to a {@link ByteBuf}
+ * {@link ByteOutput} implementation which writes the data to a {@link Buffer}
  */
 class ChannelBufferByteOutput implements ByteOutput {
 
-    private final ByteBuf buffer;
+    private final Buffer buffer;
 
     /**
-     * Create a new instance which use the given {@link ByteBuf}
+     * Create a new instance which use the given {@link Buffer}
      */
-    ChannelBufferByteOutput(ByteBuf buffer) {
+    ChannelBufferByteOutput(Buffer buffer) {
         this.buffer = buffer;
     }
 
@@ -40,13 +40,13 @@ class ChannelBufferByteOutput implements ByteOutput {
     }
 
     @Override
-    public void flush() throws IOException {
+    public void flush() {
         // nothing to do
     }
 
     @Override
     public void write(int b) throws IOException {
-        buffer.writeByte(b);
+        buffer.writeByte((byte) b);
     }
 
     @Override
@@ -60,9 +60,9 @@ class ChannelBufferByteOutput implements ByteOutput {
     }
 
     /**
-     * Return the {@link ByteBuf} which contains the written content
+     * Return the {@link Buffer} which contains the written content
      */
-    ByteBuf getBuffer() {
+    Buffer getBuffer() {
         return buffer;
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty5.handler.codec.TooLongFrameException;
@@ -28,7 +28,7 @@ import java.io.StreamCorruptedException;
  * Decoder which MUST be used with {@link MarshallingEncoder}.
  * <p>
  * A {@link LengthFieldBasedFrameDecoder} which use an {@link Unmarshaller} to read the Object out
- * of the {@link ByteBuf}.
+ * of the {@link Buffer}.
  */
 public class MarshallingDecoder extends LengthFieldBasedFrameDecoder {
 
@@ -58,8 +58,8 @@ public class MarshallingDecoder extends LengthFieldBasedFrameDecoder {
     }
 
     @Override
-    protected Object decode0(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
-        ByteBuf frame = (ByteBuf) super.decode0(ctx, in);
+    protected Object decode0(ChannelHandlerContext ctx, Buffer in) throws Exception {
+        Buffer frame = (Buffer) super.decode0(ctx, in);
         if (frame == null) {
             return null;
         }
@@ -73,10 +73,5 @@ public class MarshallingDecoder extends LengthFieldBasedFrameDecoder {
             unmarshaller.finish();
             return obj;
         }
-    }
-
-    @Override
-    protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
-        return buffer.slice(index, length);
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.contrib.handler.codec.marshalling;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import org.jboss.marshalling.Marshaller;
@@ -32,7 +31,6 @@ import org.jboss.marshalling.Marshaller;
  * See <a href="https://www.jboss.org/jbossmarshalling">JBoss Marshalling website</a>
  * for more information
  */
-@Sharable
 public class MarshallingEncoder extends MessageToByteEncoder<Object> {
 
     private static final byte[] LENGTH_PLACEHOLDER = new byte[4];
@@ -64,5 +62,10 @@ public class MarshallingEncoder extends MessageToByteEncoder<Object> {
         marshaller.close();
 
         out.setInt(lengthPos, out.writerOffset() - lengthPos - 4);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoder.java
@@ -20,7 +20,6 @@ import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.ByteToMessageDecoder;
@@ -61,7 +60,6 @@ import static java.util.Objects.requireNonNull;
  * }
  * </pre>
  */
-@Sharable
 public class ProtobufDecoder extends MessageToMessageDecoder<Buffer> {
 
     private static final boolean HAS_PARSER;
@@ -122,5 +120,10 @@ public class ProtobufDecoder extends MessageToMessageDecoder<Buffer> {
                         array, offset, length, extensionRegistry).build());
             }
         }
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoder.java
@@ -19,8 +19,7 @@ import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
@@ -32,7 +31,7 @@ import io.netty5.handler.codec.MessageToMessageDecoder;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Decodes a received {@link ByteBuf} into a
+ * Decodes a received {@link Buffer} into a
  * <a href="https://github.com/google/protobuf">Google Protocol Buffers</a>
  * {@link Message} and {@link MessageLite}. Please note that this decoder must
  * be used with a proper {@link ByteToMessageDecoder} such as {@link ProtobufVarint32FrameDecoder}
@@ -51,7 +50,7 @@ import static java.util.Objects.requireNonNull;
  * pipeline.addLast("frameEncoder", new {@link LengthFieldPrepender}(4));
  * pipeline.addLast("protobufEncoder", new {@link ProtobufEncoder}());
  * </pre>
- * and then you can use a {@code MyMessage} instead of a {@link ByteBuf}
+ * and then you can use a {@code MyMessage} instead of a {@link Buffer}
  * as a message:
  * <pre>
  * void channelRead({@link ChannelHandlerContext} ctx, Object msg) {
@@ -63,7 +62,7 @@ import static java.util.Objects.requireNonNull;
  * </pre>
  */
 @Sharable
-public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
+public class ProtobufDecoder extends MessageToMessageDecoder<Buffer> {
 
     private static final boolean HAS_PARSER;
 
@@ -101,17 +100,12 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
-        final byte[] array;
-        final int offset;
+    protected void decode(ChannelHandlerContext ctx, Buffer msg) throws Exception {
         final int length = msg.readableBytes();
-        if (msg.hasArray()) {
-            array = msg.array();
-            offset = msg.arrayOffset() + msg.readerIndex();
-        } else {
-            array = ByteBufUtil.getBytes(msg, msg.readerIndex(), length, false);
-            offset = 0;
-        }
+        final byte[] array = new byte[length];
+        final int offset;
+        msg.copyInto(msg.readerOffset(), array, 0, length);
+        offset = 0;
 
         if (extensionRegistry == null) {
             if (HAS_PARSER) {

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoderNano.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoderNano.java
@@ -17,7 +17,6 @@ package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.nano.MessageNano;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.ByteToMessageDecoder;
@@ -56,7 +55,6 @@ import static java.util.Objects.requireNonNull;
  * }
  * </pre>
  */
-@Sharable
 public class ProtobufDecoderNano extends MessageToMessageDecoder<Buffer> {
     private final Class<? extends MessageNano> clazz;
 
@@ -76,5 +74,10 @@ public class ProtobufDecoderNano extends MessageToMessageDecoder<Buffer> {
         offset = 0;
         MessageNano prototype = clazz.getConstructor().newInstance();
         ctx.fireChannelRead(MessageNano.mergeFrom(prototype, array, offset, length));
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.protobuf;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.MessageLiteOrBuilder;
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
@@ -28,12 +28,10 @@ import io.netty5.handler.codec.MessageToMessageEncoder;
 
 import java.util.List;
 
-import static io.netty.buffer.Unpooled.wrappedBuffer;
-
 /**
  * Encodes the requested <a href="https://github.com/google/protobuf">Google
  * Protocol Buffers</a> {@link Message} and {@link MessageLite} into a
- * {@link ByteBuf}. A typical setup for TCP/IP would be:
+ * {@link Buffer}. A typical setup for TCP/IP would be:
  * <pre>
  * {@link ChannelPipeline} pipeline = ...;
  *
@@ -47,7 +45,7 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
  * pipeline.addLast("frameEncoder", new {@link LengthFieldPrepender}(4));
  * pipeline.addLast("protobufEncoder", new {@link ProtobufEncoder}());
  * </pre>
- * and then you can use a {@code MyMessage} instead of a {@link ByteBuf}
+ * and then you can use a {@code MyMessage} instead of a {@link Buffer}
  * as a message:
  * <pre>
  * void channelRead({@link ChannelHandlerContext} ctx, Object msg) {
@@ -61,14 +59,13 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 @Sharable
 public class ProtobufEncoder extends MessageToMessageEncoder<MessageLiteOrBuilder> {
     @Override
-    protected void encode(ChannelHandlerContext ctx, MessageLiteOrBuilder msg, List<Object> out)
-            throws Exception {
+    protected void encode(ChannelHandlerContext ctx, MessageLiteOrBuilder msg, List<Object> out) {
         if (msg instanceof MessageLite) {
-            out.add(wrappedBuffer(((MessageLite) msg).toByteArray()));
+            out.add(ctx.bufferAllocator().copyOf(((MessageLite) msg).toByteArray()));
             return;
         }
         if (msg instanceof MessageLite.Builder) {
-            out.add(wrappedBuffer(((MessageLite.Builder) msg).build().toByteArray()));
+            out.add(ctx.bufferAllocator().copyOf(((MessageLite.Builder) msg).build().toByteArray()));
         }
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoder.java
@@ -19,7 +19,6 @@ import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.MessageLiteOrBuilder;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
@@ -56,7 +55,6 @@ import java.util.List;
  * }
  * </pre>
  */
-@Sharable
 public class ProtobufEncoder extends MessageToMessageEncoder<MessageLiteOrBuilder> {
     @Override
     protected void encode(ChannelHandlerContext ctx, MessageLiteOrBuilder msg, List<Object> out) {
@@ -67,5 +65,10 @@ public class ProtobufEncoder extends MessageToMessageEncoder<MessageLiteOrBuilde
         if (msg instanceof MessageLite.Builder) {
             out.add(ctx.bufferAllocator().copyOf(((MessageLite.Builder) msg).build().toByteArray()));
         }
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoderNano.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoderNano.java
@@ -18,7 +18,6 @@ package io.netty.contrib.handler.codec.protobuf;
 import com.google.protobuf.nano.CodedOutputByteBufferNano;
 import com.google.protobuf.nano.MessageNano;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
@@ -55,7 +54,6 @@ import java.util.List;
  * }
  * </pre>
  */
-@ChannelHandler.Sharable
 public class ProtobufEncoderNano extends MessageToMessageEncoder<MessageNano> {
     @Override
     protected void encode(ChannelHandlerContext ctx, MessageNano msg, List<Object> out) throws Exception {
@@ -64,5 +62,10 @@ public class ProtobufEncoderNano extends MessageToMessageEncoder<MessageNano> {
         CodedOutputByteBufferNano cobbn = CodedOutputByteBufferNano.newInstance(array, 0, size);
         msg.writeTo(cobbn);
         out.add(ctx.bufferAllocator().copyOf(array));
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
@@ -18,7 +18,6 @@ package io.netty.contrib.handler.codec.protobuf;
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.nano.CodedOutputByteBufferNano;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 
@@ -37,7 +36,6 @@ import io.netty5.handler.codec.MessageToByteEncoder;
  * @see CodedOutputStream
  * @see CodedOutputByteBufferNano
  */
-@Sharable
 public class ProtobufVarint32LengthFieldPrepender extends MessageToByteEncoder<Buffer> {
 
     /**
@@ -92,5 +90,10 @@ public class ProtobufVarint32LengthFieldPrepender extends MessageToByteEncoder<B
         out.ensureWritable(headerLen + bodyLen);
         writeRawVarint32(out, bodyLen);
         out.writeBytes(msg);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.nano.CodedOutputByteBufferNano;
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
@@ -38,21 +38,21 @@ import io.netty5.handler.codec.MessageToByteEncoder;
  * @see CodedOutputByteBufferNano
  */
 @Sharable
-public class ProtobufVarint32LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
+public class ProtobufVarint32LengthFieldPrepender extends MessageToByteEncoder<Buffer> {
 
     /**
-     * Writes protobuf varint32 to (@link ByteBuf).
+     * Writes protobuf varint32 to (@link Buffer).
      *
      * @param out   to be written to
      * @param value to be written
      */
-    static void writeRawVarint32(ByteBuf out, int value) {
+    static void writeRawVarint32(Buffer out, int value) {
         while (true) {
             if ((value & ~0x7F) == 0) {
-                out.writeByte(value);
+                out.writeByte((byte) value);
                 return;
             } else {
-                out.writeByte(value & 0x7F | 0x80);
+                out.writeByte((byte) (value & 0x7F | 0x80));
                 value >>>= 7;
             }
         }
@@ -81,12 +81,16 @@ public class ProtobufVarint32LengthFieldPrepender extends MessageToByteEncoder<B
     }
 
     @Override
-    protected void encode(
-            ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out) throws Exception {
+    protected Buffer allocateBuffer(ChannelHandlerContext ctx, Buffer buffer) {
+        return ctx.bufferAllocator().allocate(0);
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, Buffer msg, Buffer out) {
         int bodyLen = msg.readableBytes();
         int headerLen = computeRawVarint32Size(bodyLen);
         out.ensureWritable(headerLen + bodyLen);
         writeRawVarint32(out, bodyLen);
-        out.writeBytes(msg, msg.readerIndex(), bodyLen);
+        out.writeBytes(msg);
     }
 }

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/package-info.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/package-info.java
@@ -18,6 +18,6 @@
  * Encoder and decoder which transform a
  * <a href="https://github.com/google/protobuf">Google Protocol Buffers</a>
  * {@link com.google.protobuf.Message} and {@link com.google.protobuf.nano.MessageNano} into a
- * {@link io.netty.buffer.ByteBuf} and vice versa.
+ * {@link io.netty5.buffer.api.Buffer} and vice versa.
  */
 package io.netty.contrib.handler.codec.protobuf;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoder.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufOutputStream;
+import io.netty5.buffer.BufferOutputStream;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 
@@ -28,7 +28,7 @@ import java.io.Serializable;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
- * An encoder which serializes a Java object into a {@link ByteBuf}
+ * An encoder which serializes a Java object into a {@link Buffer}
  * (interoperability version).
  * <p>
  * This encoder is interoperable with the standard Java object streams such as
@@ -43,6 +43,11 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
      */
     public CompatibleObjectEncoder() {
         this(16); // Reset at every sixteen writes
+    }
+
+    @Override
+    protected Buffer allocateBuffer(ChannelHandlerContext ctx, Serializable serializable) {
+        return ctx.bufferAllocator().allocate(256);
     }
 
     /**
@@ -67,8 +72,8 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, Serializable msg, ByteBuf out) throws Exception {
-        try (ObjectOutputStream oos = newObjectOutputStream(new ByteBufOutputStream(out))) {
+    protected void encode(ChannelHandlerContext ctx, Serializable msg, Buffer out) throws Exception {
+        try (ObjectOutputStream oos = newObjectOutputStream(new BufferOutputStream(out))) {
             if (resetInterval != 0) {
                 // Resetting will prevent OOM on the receiving side.
                 writtenObjects++;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectDecoder.java
@@ -15,18 +15,17 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
 import io.netty5.buffer.BufferInputStream;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.LengthFieldBasedFrameDecoderForBuffer;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.StreamCorruptedException;
 
 /**
- * A decoder which deserializes the received {@link ByteBuf}s into Java
+ * A decoder which deserializes the received {@link Buffer}s into Java
  * objects.
  * <p>
  * Please note that the serialized form this decoder expects is not
@@ -34,7 +33,7 @@ import java.io.StreamCorruptedException;
  * {@link ObjectEncoder} or {@link ObjectEncoderOutputStream} to ensure the
  * interoperability with this decoder.
  */
-public class ObjectDecoder extends LengthFieldBasedFrameDecoderForBuffer {
+public class ObjectDecoder extends LengthFieldBasedFrameDecoder {
 
     private final ClassResolver classResolver;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoder.java
@@ -15,19 +15,18 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
 import io.netty5.buffer.BufferOutputStream;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
+import io.netty5.handler.codec.MessageToByteEncoder;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 /**
- * An encoder which serializes a Java object into a {@link ByteBuf}.
+ * An encoder which serializes a Java object into a {@link Buffer}.
  * <p>
  * Please note that the serialized form this encoder produces is not
  * compatible with the standard {@link ObjectInputStream}.  Please use
@@ -35,11 +34,11 @@ import java.io.Serializable;
  * interoperability with this encoder.
  */
 @Sharable
-public class ObjectEncoder extends MessageToByteEncoderForBuffer<Serializable> {
+public class ObjectEncoder extends MessageToByteEncoder<Serializable> {
     private static final byte[] LENGTH_PLACEHOLDER = new byte[4];
 
     @Override
-    protected Buffer allocateBuffer(ChannelHandlerContext ctx, Serializable msg) throws Exception {
+    protected Buffer allocateBuffer(ChannelHandlerContext ctx, Serializable msg) {
         return ctx.bufferAllocator().allocate(256);
     }
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoder.java
@@ -17,7 +17,6 @@ package io.netty.contrib.handler.codec.serialization;
 
 import io.netty5.buffer.BufferOutputStream;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 
@@ -33,7 +32,6 @@ import java.io.Serializable;
  * {@link ObjectDecoder} or {@link ObjectDecoderInputStream} to ensure the
  * interoperability with this encoder.
  */
-@Sharable
 public class ObjectEncoder extends MessageToByteEncoder<Serializable> {
     private static final byte[] LENGTH_PLACEHOLDER = new byte[4];
 
@@ -63,5 +61,10 @@ public class ObjectEncoder extends MessageToByteEncoder<Serializable> {
 
         int endIdx = out.writerOffset();
         out.setInt(startIdx, endIdx - startIdx - 4);
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingDecoderTest.java
@@ -15,8 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.jboss.marshalling.Marshaller;
@@ -28,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -63,8 +63,8 @@ public abstract class AbstractMarshallingDecoderTest extends AbstractMarshalling
         assertNull(ch.readInbound());
     }
 
-    protected ByteBuf input(byte[] input) {
-        return Unpooled.wrappedBuffer(input);
+    protected Buffer input(byte[] input) {
+        return preferredAllocator().copyOf(input);
     }
 
     @Test
@@ -83,8 +83,8 @@ public abstract class AbstractMarshallingDecoderTest extends AbstractMarshalling
 
         byte[] testBytes = bout.toByteArray();
 
-        ByteBuf buffer = input(testBytes);
-        ByteBuf slice = buffer.readRetainedSlice(2);
+        Buffer buffer = input(testBytes);
+        Buffer slice = buffer.readSplit(2);
 
         ch.writeInbound(slice);
         ch.writeInbound(buffer);
@@ -116,7 +116,7 @@ public abstract class AbstractMarshallingDecoderTest extends AbstractMarshalling
         onTooBigFrame(ch, input(testBytes));
     }
 
-    protected void onTooBigFrame(EmbeddedChannel ch, ByteBuf input) {
+    protected void onTooBigFrame(EmbeddedChannel ch, Buffer input) {
         ch.writeInbound(input);
         assertFalse(ch.isActive());
     }

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingDecoderTest.java
@@ -15,8 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CodecException;
 import io.netty5.handler.codec.TooLongFrameException;
@@ -24,6 +23,9 @@ import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
 
+import java.util.List;
+
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -43,14 +45,14 @@ public class RiverMarshallingDecoderTest extends AbstractMarshallingDecoderTest 
     }
 
     @Override
-    protected ByteBuf input(byte[] input) {
-        ByteBuf length = Unpooled.buffer(4);
+    protected Buffer input(byte[] input) {
+        Buffer length = preferredAllocator().allocate(4);
         length.writeInt(input.length);
-        return Unpooled.wrappedBuffer(length, Unpooled.wrappedBuffer(input));
+        return preferredAllocator().compose(List.of(length.send(), preferredAllocator().copyOf(input).send()));
     }
 
     @Override
-    protected void onTooBigFrame(EmbeddedChannel ch, ByteBuf input) {
+    protected void onTooBigFrame(EmbeddedChannel ch, Buffer input) {
         try {
             ch.writeInbound(input);
             fail();

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingEncoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
@@ -36,8 +36,8 @@ public class RiverMarshallingEncoderTest extends AbstractMarshallingEncoderTest 
     }
 
     @Override
-    protected ByteBuf truncate(ByteBuf buf) {
+    protected Buffer truncate(Buffer buf) {
         buf.readInt();
-        return buf;
+        return buf.split();
     }
 }

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingDecoderTest.java
@@ -15,8 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CodecException;
 import io.netty5.handler.codec.TooLongFrameException;
@@ -24,6 +23,9 @@ import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
 
+import java.util.List;
+
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -43,14 +45,14 @@ public class SerialMarshallingDecoderTest extends AbstractMarshallingDecoderTest
     }
 
     @Override
-    protected ByteBuf input(byte[] input) {
-        ByteBuf length = Unpooled.buffer(4);
+    protected Buffer input(byte[] input) {
+        Buffer length = preferredAllocator().allocate(4);
         length.writeInt(input.length);
-        return Unpooled.wrappedBuffer(length, Unpooled.wrappedBuffer(input));
+        return preferredAllocator().compose(List.of(length.send(), preferredAllocator().copyOf(input).send()));
     }
 
     @Override
-    protected void onTooBigFrame(EmbeddedChannel ch, ByteBuf input) {
+    protected void onTooBigFrame(EmbeddedChannel ch, Buffer input) {
         try {
             ch.writeInbound(input);
             fail();

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingEncoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
@@ -36,8 +36,8 @@ public class SerialMarshallingEncoderTest extends AbstractMarshallingEncoderTest
     }
 
     @Override
-    protected ByteBuf truncate(ByteBuf buf) {
+    protected Buffer truncate(Buffer buf) {
         buf.readInt();
-        return buf;
+        return buf.split();
     }
 }

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -15,12 +15,11 @@
  */
 package io.netty.contrib.handler.codec.protobuf;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,16 +44,14 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         for (int i = size; i < num + size; ++i) {
             buf[i] = 1;
         }
-        assertTrue(ch.writeOutbound(wrappedBuffer(buf, size, buf.length - size)));
+        Buffer buffer = ch.bufferAllocator().allocate(buf.length - size);
+        assertTrue(ch.writeOutbound(buffer.writeBytes(buf, size, buf.length - size)));
 
-        ByteBuf expected = wrappedBuffer(buf);
-        ByteBuf actual = ch.readOutbound();
-
-        assertThat(expected).isEqualTo(actual);
+        try (Buffer expected = ch.bufferAllocator().copyOf(buf);
+             Buffer actual = ch.readOutbound()) {
+            assertThat(expected).isEqualTo(actual);
+        }
         assertFalse(ch.finish());
-
-        expected.release();
-        actual.release();
     }
 
     @Test
@@ -80,16 +77,14 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         for (int i = size; i < num + size; ++i) {
             buf[i] = 1;
         }
-        assertTrue(ch.writeOutbound(wrappedBuffer(buf, size, buf.length - size)));
+        Buffer buffer = ch.bufferAllocator().allocate(buf.length - size);
+        assertTrue(ch.writeOutbound(buffer.writeBytes(buf, size, buf.length - size)));
 
-        ByteBuf expected = wrappedBuffer(buf);
-        ByteBuf actual = ch.readOutbound();
-
-        assertThat(actual).isEqualTo(expected);
+        try (Buffer expected = ch.bufferAllocator().copyOf(buf);
+        Buffer actual = ch.readOutbound()) {
+            assertThat(actual).isEqualTo(expected);
+        }
         assertFalse(ch.finish());
-
-        expected.release();
-        actual.release();
     }
 
     @Test
@@ -116,16 +111,14 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         for (int i = size; i < num + size; ++i) {
             buf[i] = 1;
         }
-        assertTrue(ch.writeOutbound(wrappedBuffer(buf, size, buf.length - size)));
+        Buffer buffer = ch.bufferAllocator().allocate(buf.length - size);
+        assertTrue(ch.writeOutbound(buffer.writeBytes(buf, size, buf.length - size)));
 
-        ByteBuf expected = wrappedBuffer(buf);
-        ByteBuf actual = ch.readOutbound();
-
-        assertThat(expected).isEqualTo(actual);
+        try (Buffer expected = ch.bufferAllocator().copyOf(buf);
+        Buffer actual = ch.readOutbound()) {
+            assertThat(expected).isEqualTo(actual);
+        }
         assertFalse(ch.finish());
-
-        expected.release();
-        actual.release();
     }
 
     @Test
@@ -153,31 +146,27 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         for (int i = size; i < num + size; ++i) {
             buf[i] = 1;
         }
-        assertTrue(ch.writeOutbound(wrappedBuffer(buf, size, buf.length - size)));
+        Buffer buffer = ch.bufferAllocator().allocate(buf.length - size);
+        assertTrue(ch.writeOutbound(buffer.writeBytes(buf, size, buf.length - size)));
 
-        ByteBuf expected = wrappedBuffer(buf);
-        ByteBuf actual = ch.readOutbound();
-
-        assertThat(actual).isEqualTo(expected);
+        try (Buffer expected = ch.bufferAllocator().copyOf(buf);
+        Buffer actual = ch.readOutbound()) {
+            assertThat(actual).isEqualTo(expected);
+        }
         assertFalse(ch.finish());
-
-        expected.release();
-        actual.release();
     }
 
     @Test
     public void testTinyEncode() {
         byte[] b = {4, 1, 1, 1, 1};
-        assertTrue(ch.writeOutbound(wrappedBuffer(b, 1, b.length - 1)));
+        Buffer buffer = ch.bufferAllocator().allocate(b.length - 1);
+        assertTrue(ch.writeOutbound(buffer.writeBytes(b, 1, b.length - 1)));
 
-        ByteBuf expected = wrappedBuffer(b);
-        ByteBuf actual = ch.readOutbound();
-
-        assertThat(actual).isEqualTo(expected);
+        try (Buffer expected = ch.bufferAllocator().copyOf(b);
+        Buffer actual = ch.readOutbound()) {
+            assertThat(actual).isEqualTo(expected);
+        }
         assertFalse(ch.finish());
-
-        expected.release();
-        actual.release();
     }
 
     @Test
@@ -188,15 +177,13 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         }
         b[0] = -2;
         b[1] = 15;
-        assertTrue(ch.writeOutbound(wrappedBuffer(b, 2, b.length - 2)));
+        Buffer buffer = ch.bufferAllocator().allocate(b.length - 2);
+        assertTrue(ch.writeOutbound(buffer.writeBytes(b, 2, b.length - 2)));
 
-        ByteBuf expected = wrappedBuffer(b);
-        ByteBuf actual = ch.readOutbound();
-
-        assertThat(actual).isEqualTo(expected);
+        try (Buffer expected = ch.bufferAllocator().copyOf(b);
+        Buffer actual = ch.readOutbound()) {
+            assertThat(actual).isEqualTo(expected);
+        }
         assertFalse(ch.finish());
-
-        expected.release();
-        actual.release();
     }
 }

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoderTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.serialization;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufInputStream;
+import io.netty5.buffer.BufferInputStream;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
@@ -31,14 +31,9 @@ public class CompatibleObjectEncoderTest {
     private static void testEncode(EmbeddedChannel channel, TestSerializable original)
             throws IOException, ClassNotFoundException {
         channel.writeOutbound(original);
-        Object o = channel.readOutbound();
-        ByteBuf buf = (ByteBuf) o;
-        ObjectInputStream ois = new ObjectInputStream(new ByteBufInputStream(buf));
-        try {
+        try (Buffer buf = channel.readOutbound();
+             ObjectInputStream ois = new ObjectInputStream(new BufferInputStream(buf.send()))) {
             assertEquals(original, ois.readObject());
-        } finally {
-            buf.release();
-            ois.close();
         }
     }
 

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoderTest.java
@@ -16,8 +16,7 @@
 
 package io.netty.contrib.handler.codec.xml;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CorruptedFrameException;
 import io.netty5.handler.codec.TooLongFrameException;
@@ -56,19 +55,19 @@ public class XmlFrameDecoderTest {
         Exception cause = null;
         try {
             for (String xmlFrame : xmlFrames) {
-                ch.writeInbound(Unpooled.copiedBuffer(xmlFrame, CharsetUtil.UTF_8));
+                ch.writeInbound(ch.bufferAllocator().copyOf(xmlFrame, CharsetUtil.UTF_8));
             }
         } catch (Exception e) {
             cause = e;
         }
         List<Object> actual = new ArrayList<>();
         for (; ; ) {
-            ByteBuf buf = ch.readInbound();
-            if (buf == null) {
-                break;
+            try (Buffer buf = ch.readInbound()) {
+                if (buf == null) {
+                    break;
+                }
+                actual.add(buf.toString(CharsetUtil.UTF_8));
             }
-            actual.add(buf.toString(CharsetUtil.UTF_8));
-            buf.release();
         }
 
         if (cause != null) {
@@ -103,7 +102,7 @@ public class XmlFrameDecoderTest {
         XmlFrameDecoder decoder = new XmlFrameDecoder(3);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
         assertThrows(TooLongFrameException.class,
-                () -> ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8)));
+                () -> ch.writeInbound(ch.bufferAllocator().copyOf("<v/>", CharsetUtil.UTF_8)));
     }
 
     @Test
@@ -111,7 +110,7 @@ public class XmlFrameDecoderTest {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
         assertThrows(CorruptedFrameException.class,
-                () -> ch.writeInbound(Unpooled.copiedBuffer("invalid XML", CharsetUtil.UTF_8)));
+                () -> ch.writeInbound(ch.bufferAllocator().copyOf("invalid XML", CharsetUtil.UTF_8)));
     }
 
     @Test
@@ -119,7 +118,7 @@ public class XmlFrameDecoderTest {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
         assertThrows(CorruptedFrameException.class,
-                () -> ch.writeInbound(Unpooled.copiedBuffer("invalid XML<foo/>", CharsetUtil.UTF_8)));
+                () -> ch.writeInbound(ch.bufferAllocator().copyOf("invalid XML<foo/>", CharsetUtil.UTF_8)));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
     </developers>
 
     <properties>
-        <nettyByteBuf.version>4.1.75.Final</nettyByteBuf.version>
         <netty.version>5.0.0.Alpha3-SNAPSHOT</netty.version>
         <netty.build.version>29</netty.build.version>
         <project.scm.id>github</project.scm.id>


### PR DESCRIPTION
Motivation:

Helps to have a pipeline working only with `Buffer` API

Modifications:

- Port `codec-extras` to `Buffer` API
- Adapt the junit tests

Result:

`codec-extras` now is using the `Buffer` API