### PR TITLE
Adapt to changes made in Future interface

### DIFF
--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/SocketObjectEchoTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/SocketObjectEchoTest.java
@@ -94,8 +94,8 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().get();
-        Channel cc = cb.connect(sc.localAddress()).get();
+        Channel sc = sb.bind().asStage().get();
+        Channel cc = cb.connect(sc.localAddress()).asStage().get();
         for (String element : data) {
             cc.writeAndFlush(element);
         }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClient.java
@@ -70,7 +70,7 @@ public final class ObjectEchoClient {
                     });
 
             // Start the connection attempt.
-            b.connect(HOST, PORT).get().closeFuture().sync();
+            b.connect(HOST, PORT).asStage().get().closeFuture().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServer.java
@@ -72,7 +72,7 @@ public final class ObjectEchoServer {
                     });
 
             // Bind and start to accept incoming connections.
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockClient.java
@@ -58,7 +58,7 @@ public final class WorldClockClient {
                     .handler(new WorldClockClientInitializer(sslCtx));
 
             // Make a new connection.
-            Channel ch = b.connect(HOST, PORT).get();
+            Channel ch = b.connect(HOST, PORT).asStage().get();
 
             // Get the handler instance to initiate the request.
             WorldClockClientHandler handler = ch.pipeline().get(WorldClockClientHandler.class);

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServer.java
@@ -54,7 +54,7 @@ public final class WorldClockServer {
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new WorldClockServerInitializer(sslCtx));
 
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();


### PR DESCRIPTION
Motivation:

blocking JDK Future methods have moved to FutureCompletableStage interface: see https://github.com/netty/netty/pull/12548
The code needs to be adapted.

Modifications:
Changed _Future.get()_  to _Future.asStage().get()_

Result:

The code is adapted to the new changes in the API.