### PR TITLE
Adapt to changes made in Future interface

### DIFF
--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/SocketObjectEchoTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/SocketObjectEchoTest.java
@@ -130,9 +130,9 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
             }
         }
 
-        sh.channel.close().sync();
-        ch.channel.close().sync();
-        sc.close().sync();
+        sh.channel.close().asStage().sync();
+        ch.channel.close().asStage().sync();
+        sc.close().asStage().sync();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoClient.java
@@ -70,7 +70,7 @@ public final class ObjectEchoClient {
                     });
 
             // Start the connection attempt.
-            b.connect(HOST, PORT).asStage().get().closeFuture().sync();
+            b.connect(HOST, PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/objectecho/ObjectEchoServer.java
@@ -72,7 +72,7 @@ public final class ObjectEchoServer {
                     });
 
             // Bind and start to accept incoming connections.
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/example/worldclock/WorldClockServer.java
@@ -54,7 +54,7 @@ public final class WorldClockServer {
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new WorldClockServerInitializer(sslCtx));
 
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();


### PR DESCRIPTION
Motivation:

The `sync()` method have been removed from the `Future` interface and added to
the `FutureCompletionStage` interface.
https://github.com/netty/netty/pull/12569
The code needs to be adapted.

Modifications:

- Changed `Future.sync()` to `Future.asStage().sync()`

Result:

The code is adapted to the new changes in the API.