### PR TITLE
Fix remaining javadocs issues

### DIFF
--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -27,13 +27,13 @@ import io.netty5.handler.codec.CorruptedFrameException;
  * value of the Google Protocol Buffers
  * <a href="https://developers.google.com/protocol-buffers/docs/encoding#varints">Base
  * 128 Varints</a> integer length field in the message. For example:
- * <pre>{@code
+ * <pre>
  * BEFORE DECODE (302 bytes)       AFTER DECODE (300 bytes)
  * +--------+---------------+      +---------------+
  * | Length | Protobuf Data |----->| Protobuf Data |
  * | 0xAC02 |  (300 bytes)  |      |  (300 bytes)  |
  * +--------+---------------+      +---------------+
- * }</pre>
+ * </pre>
  *
  * @see CodedInputStream
  * @see CodedInputByteBufferNano

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -27,13 +27,13 @@ import io.netty5.handler.codec.CorruptedFrameException;
  * value of the Google Protocol Buffers
  * <a href="https://developers.google.com/protocol-buffers/docs/encoding#varints">Base
  * 128 Varints</a> integer length field in the message. For example:
- * <pre>
+ * <pre>{@code
  * BEFORE DECODE (302 bytes)       AFTER DECODE (300 bytes)
  * +--------+---------------+      +---------------+
  * | Length | Protobuf Data |----->| Protobuf Data |
  * | 0xAC02 |  (300 bytes)  |      |  (300 bytes)  |
  * +--------+---------------+      +---------------+
- * </pre>
+ * }</pre>
  *
  * @see CodedInputStream
  * @see CodedInputByteBufferNano

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
@@ -25,13 +25,13 @@ import io.netty5.handler.codec.MessageToByteEncoder;
  * An encoder that prepends the Google Protocol Buffers
  * <a href="https://developers.google.com/protocol-buffers/docs/encoding?csw=1#varints">Base
  * 128 Varints</a> integer length field. For example:
- * <pre>
+ * <pre>{@code
  * BEFORE ENCODE (300 bytes)       AFTER ENCODE (302 bytes)
  * +---------------+               +--------+---------------+
  * | Protobuf Data |-------------->| Length | Protobuf Data |
  * |  (300 bytes)  |               | 0xAC02 |  (300 bytes)  |
  * +---------------+               +--------+---------------+
- * </pre> *
+ * }</pre>
  *
  * @see CodedOutputStream
  * @see CodedOutputByteBufferNano

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoder.java
@@ -37,7 +37,6 @@ import static io.netty5.util.internal.ObjectUtil.checkPositive;
  * </pre>
  * <p>
  * this decoder would output a single frame:
- * <p>
  * <pre>
  * +-----------------+
  * | &lt;anXmlElement/&gt; |
@@ -52,7 +51,6 @@ import static io.netty5.util.internal.ObjectUtil.checkPositive;
  * </pre>
  * <p>
  * this decoder would output two frames:
- * <p>
  * <pre>
  * +-----------------+-------------------------------------+
  * | &lt;anXmlElement/&gt; | &lt;root&gt;&lt;child&gt;content&lt;/child&gt;&lt;/root&gt; |


### PR DESCRIPTION
Motivation:
Javadocs are being checked more strictly now, so these issues need to be fixed in order to make a release.

Modification:
Fix reported javadocs issues.

Result:
Javadocs should be in a shape to pass release.