### PR TITLE
Adapt to the changed package for Buffer API

### DIFF
--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/json/JsonObjectDecoder.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.json;
 
 import io.netty5.buffer.BufferUtil;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteInput.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteInput.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import org.jboss.marshalling.ByteInput;
 
 import java.io.IOException;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteOutput.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/ChannelBufferByteOutput.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import org.jboss.marshalling.ByteOutput;
 
 import java.io.IOException;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty5.handler.codec.TooLongFrameException;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/marshalling/MarshallingEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import org.jboss.marshalling.Marshaller;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoder.java
@@ -19,7 +19,7 @@ import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.ByteToMessageDecoder;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoderNano.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufDecoderNano.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.nano.MessageNano;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.ByteToMessageDecoder;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.protobuf;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.MessageLiteOrBuilder;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoderNano.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufEncoderNano.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.nano.CodedOutputByteBufferNano;
 import com.google.protobuf.nano.MessageNano;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.nano.CodedInputByteBufferNano;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.CorruptedFrameException;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.protobuf;
 
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.nano.CodedOutputByteBufferNano;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/package-info.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/protobuf/package-info.java
@@ -18,6 +18,6 @@
  * Encoder and decoder which transform a
  * <a href="https://github.com/google/protobuf">Google Protocol Buffers</a>
  * {@link com.google.protobuf.Message} and {@link com.google.protobuf.nano.MessageNano} into a
- * {@link io.netty5.buffer.api.Buffer} and vice versa.
+ * {@link io.netty5.buffer.Buffer} and vice versa.
  */
 package io.netty.contrib.handler.codec.protobuf;

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoder.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.serialization;
 
 import io.netty5.buffer.BufferOutputStream;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectDecoder.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.serialization;
 
 import io.netty5.buffer.BufferInputStream;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoder.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.serialization;
 
 import io.netty5.buffer.BufferOutputStream;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoderOutputStream.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/serialization/ObjectEncoderOutputStream.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.serialization;
 
 import io.netty5.buffer.BufferOutputStream;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -24,7 +24,7 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/codec-extras/src/main/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoder.java
+++ b/codec-extras/src/main/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.xml;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.CorruptedFrameException;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/json/JsonObjectDecoderTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.json;
 
-import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CorruptedFrameException;
 import io.netty5.handler.codec.TooLongFrameException;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.jboss.marshalling.Marshaller;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/AbstractMarshallingEncoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.jboss.marshalling.MarshallerFactory;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CodecException;
 import io.netty5.handler.codec.TooLongFrameException;
@@ -25,7 +25,7 @@ import org.jboss.marshalling.MarshallingConfiguration;
 
 import java.util.List;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/RiverMarshallingEncoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CodecException;
 import io.netty5.handler.codec.TooLongFrameException;
@@ -25,7 +25,7 @@ import org.jboss.marshalling.MarshallingConfiguration;
 
 import java.util.List;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/marshalling/SerialMarshallingEncoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.marshalling;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.protobuf;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.protobuf;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/serialization/CompatibleObjectEncoderTest.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.serialization;
 
 import io.netty5.buffer.BufferInputStream;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 

--- a/codec-extras/src/test/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec-extras/src/test/java/io/netty/contrib/handler/codec/xml/XmlFrameDecoderTest.java
@@ -16,7 +16,7 @@
 
 package io.netty.contrib.handler.codec.xml;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CorruptedFrameException;
 import io.netty5.handler.codec.TooLongFrameException;


### PR DESCRIPTION
Motivation:
- Buffer API package was changed from `io.netty5.buffer.api` to `io.netty5.buffer` https://github.com/netty/netty/pull/12792

Modification:
- Adapt to the changed package for Buffer API

Result:
Project build is green again