### PR TITLE
Use Netty5 ALPHA6-SNAPSHOT in order to avoid slf4j conflicts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     </developers>
 
     <properties>
-        <netty.version>5.0.0.Alpha5</netty.version>
+        <netty.version>5.0.0.Alpha6-SNAPSHOT</netty.version>
         <netty.build.version>29</netty.build.version>
         <project.scm.id>github</project.scm.id>
         <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

This project is currently depending on Netty 5.0.0-Alpha5.
Let's depend on Netty Alpha6-SNAPSHOT, this seems to avoid dependency conflicts while adapting ReactorNetty to latest Netty Alpha6-SNAPSHOT.

Modification:

Modified the pom.xml in order to depend on 5.0.0.Alpha6-SNAPSHOT instead of 5.0.0.Alpha5

Result:

This allows to avoid some dependency conflicts while adapting ReactorNetty to the latest Netty Alpha6-SNAPSHOT


